### PR TITLE
add yahpo benchmark templates, require v2

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Yahpo Gym and data
         run: |
           cd ~/work
-          git clone -b yahpo_v2 https://github.com/slds-lmu/yahpo_data.git
+          git clone -b v2 https://github.com/slds-lmu/yahpo_data.git
           printf "data_path: ~/work/yahpo_data\n" >> ~/.config/yahpo_gym
 
       - name: Run pytest

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Yahpo Gym and data
         run: |
           cd ~/work
-          git clone https://github.com/slds-lmu/yahpo_data.git
+          git clone -b yahpo_v2 https://github.com/slds-lmu/yahpo_data.git
           printf "data_path: ~/work/yahpo_data\n" >> ~/.config/yahpo_gym
 
       - name: Run pytest

--- a/config.py
+++ b/config.py
@@ -12,25 +12,28 @@ _C.PROBLEM.PROBLEM_TYPE = "zdt1"
 _C.PROBLEM.DIMENSIONS = 10
 
 # YAHPO Setting
-# FIXME: epochs should be fixed here see minimal_example.py
 _C.PROBLEM.ID = "lcbench"
 _C.PROBLEM.INSTANCE = 3945
 _C.PROBLEM.OBJECTIVE_NAMES = ["time", "val_accuracy"]
 
 # Fixed HPs for YAHPO
-# FIXME: different HPs for different learners are listed on the same level which can be confugsign
 _C.FIXED_HPS = CN()
 
 _C.FIXED_HPS.TRAINSIZE = (None, None)
+_C.FIXED_HPS.EPOCH = (None, None)
+_C.FIXED_HPS.REPL = (None, None)
 
 _C.FIXED_HPS.REPLACE = (None, None)
-_C.FIXED_HPS.SPLITRULE = (None, None)
 _C.FIXED_HPS.RESPECT_UNORDERED_FACTORS = (None, None)
-_C.FIXED_HPS.NUM_RANDOM_SPLITS = (None, None)
+_C.FIXED_HPS.SPLITRULE = (None, None)
 
 _C.FIXED_HPS.BOOSTER = (None, None)
+
+_C.FIXED_HPS.DEFINITION = (None, None)
+
+_C.FIXED_HPS.PRE_POST = (None, None)
+
 _C.FIXED_HPS.NUM_IMPUTE_SELECTED_CPO = (None, None)
-_C.FIXED_HPS.REPL = (None, None)
 
 _C.PROBLEM.OML_TASK = 359960
 

--- a/experiment_configs/iaml_ranger.yaml
+++ b/experiment_configs/iaml_ranger.yaml
@@ -9,5 +9,4 @@ FIXED_HPS:
   REPLACE: ("replace", "TRUE")
   RESPECT_UNORDERED_FACTORS: ("respect.unordered.factors", "ignore")
   SPLITRULE: ("splitrule", "gini")
-  NUM_RANDOM_SPLITS: ("num_random_splits", 1)
 

--- a/experiment_configs/templates/fair_fgrrm_190424.yaml
+++ b/experiment_configs/templates/fair_fgrrm_190424.yaml
@@ -1,0 +1,10 @@
+PROBLEM:
+  PROBLEM_TYPE: "yahpo"
+  ID: "fair_fgrrm"
+  INSTANCE: "190424"
+  OBJECTIVE_NAMES: ["mmce", "feo"]
+
+FIXED_HPS:
+  TRAINSIZE: ("trainsize", 1)
+  DEFINITION: ("definition", "eo-komiyama")
+

--- a/experiment_configs/templates/fair_fgrrm_31.yaml
+++ b/experiment_configs/templates/fair_fgrrm_31.yaml
@@ -1,0 +1,10 @@
+PROBLEM:
+  PROBLEM_TYPE: "yahpo"
+  ID: "fair_fgrrm"
+  INSTANCE: "31"
+  OBJECTIVE_NAMES: ["mmce", "feo"]
+
+FIXED_HPS:
+  TRAINSIZE: ("trainsize", 1)
+  DEFINITION: ("definition", "eo-komiyama")
+

--- a/experiment_configs/templates/fair_ranger_190424.yaml
+++ b/experiment_configs/templates/fair_ranger_190424.yaml
@@ -1,13 +1,13 @@
 PROBLEM:
   PROBLEM_TYPE: "yahpo"
-  ID: "iaml_ranger"
-  INSTANCE: "40981"
-  OBJECTIVE_NAMES: ["auc", "nf"]
+  ID: "fair_ranger"
+  INSTANCE: "190424"
+  OBJECTIVE_NAMES: ["mmce", "feo"]
 
 FIXED_HPS:
   TRAINSIZE: ("trainsize", 1)
+  PRE_POST: ("pre_post", "none")
   REPLACE: ("replace", "TRUE")
   RESPECT_UNORDERED_FACTORS: ("respect.unordered.factors", "ignore")
   SPLITRULE: ("splitrule", "gini")
-  NUM_RANDOM_SPLITS: ("num_random_splits", 1)
 

--- a/experiment_configs/templates/fair_ranger_31.yaml
+++ b/experiment_configs/templates/fair_ranger_31.yaml
@@ -1,13 +1,13 @@
 PROBLEM:
   PROBLEM_TYPE: "yahpo"
-  ID: "iaml_ranger"
-  INSTANCE: "40981"
-  OBJECTIVE_NAMES: ["auc", "nf"]
+  ID: "fair_ranger"
+  INSTANCE: "31"
+  OBJECTIVE_NAMES: ["mmce", "feo"]
 
 FIXED_HPS:
   TRAINSIZE: ("trainsize", 1)
+  PRE_POST: ("pre_post", "none")
   REPLACE: ("replace", "TRUE")
   RESPECT_UNORDERED_FACTORS: ("respect.unordered.factors", "ignore")
   SPLITRULE: ("splitrule", "gini")
-  NUM_RANDOM_SPLITS: ("num_random_splits", 1)
 

--- a/experiment_configs/templates/fair_rpart_190424.yaml
+++ b/experiment_configs/templates/fair_rpart_190424.yaml
@@ -1,0 +1,10 @@
+PROBLEM:
+  PROBLEM_TYPE: "yahpo"
+  ID: "fair_rpart"
+  INSTANCE: "190424"
+  OBJECTIVE_NAMES: ["mmce", "feo"]
+
+FIXED_HPS:
+  TRAINSIZE: ("trainsize", 1)
+  PRE_POST: ("pre_post", "none")
+

--- a/experiment_configs/templates/fair_rpart_31.yaml
+++ b/experiment_configs/templates/fair_rpart_31.yaml
@@ -1,0 +1,10 @@
+PROBLEM:
+  PROBLEM_TYPE: "yahpo"
+  ID: "fair_rpart"
+  INSTANCE: "31"
+  OBJECTIVE_NAMES: ["mmce", "feo"]
+
+FIXED_HPS:
+  TRAINSIZE: ("trainsize", 1)
+  PRE_POST: ("pre_post", "none")
+

--- a/experiment_configs/templates/fair_xgboost_190424.yaml
+++ b/experiment_configs/templates/fair_xgboost_190424.yaml
@@ -1,0 +1,11 @@
+PROBLEM:
+  PROBLEM_TYPE: "yahpo"
+  ID: "fair_xgboost"
+  INSTANCE: "190424"
+  OBJECTIVE_NAMES: ["mmce", "feo"]
+
+FIXED_HPS:
+  TRAINSIZE: ("trainsize", 1)
+  PRE_POST: ("pre_post", "none")
+  BOOSTER: ("booster", "gbtree")
+

--- a/experiment_configs/templates/fair_xgboost_31.yaml
+++ b/experiment_configs/templates/fair_xgboost_31.yaml
@@ -1,0 +1,11 @@
+PROBLEM:
+  PROBLEM_TYPE: "yahpo"
+  ID: "fair_xgboost"
+  INSTANCE: "31"
+  OBJECTIVE_NAMES: ["mmce", "feo"]
+
+FIXED_HPS:
+  TRAINSIZE: ("trainsize", 1)
+  PRE_POST: ("pre_post", "none")
+  BOOSTER: ("booster", "gbtree")
+

--- a/experiment_configs/templates/iaml_glmnet_1067.yaml
+++ b/experiment_configs/templates/iaml_glmnet_1067.yaml
@@ -1,0 +1,9 @@
+PROBLEM:
+  PROBLEM_TYPE: "yahpo"
+  ID: "iaml_glmnet"
+  INSTANCE: "1067"
+  OBJECTIVE_NAMES: ["auc", "nf"]
+
+FIXED_HPS:
+  TRAINSIZE: ("trainsize", 1)
+

--- a/experiment_configs/templates/iaml_glmnet_40981.yaml
+++ b/experiment_configs/templates/iaml_glmnet_40981.yaml
@@ -1,0 +1,9 @@
+PROBLEM:
+  PROBLEM_TYPE: "yahpo"
+  ID: "iaml_glmnet"
+  INSTANCE: "40981"
+  OBJECTIVE_NAMES: ["auc", "nf"]
+
+FIXED_HPS:
+  TRAINSIZE: ("trainsize", 1)
+

--- a/experiment_configs/templates/iaml_ranger_1067.yaml
+++ b/experiment_configs/templates/iaml_ranger_1067.yaml
@@ -1,7 +1,7 @@
 PROBLEM:
   PROBLEM_TYPE: "yahpo"
   ID: "iaml_ranger"
-  INSTANCE: "40981"
+  INSTANCE: "1067"
   OBJECTIVE_NAMES: ["auc", "nf"]
 
 FIXED_HPS:
@@ -9,5 +9,4 @@ FIXED_HPS:
   REPLACE: ("replace", "TRUE")
   RESPECT_UNORDERED_FACTORS: ("respect.unordered.factors", "ignore")
   SPLITRULE: ("splitrule", "gini")
-  NUM_RANDOM_SPLITS: ("num_random_splits", 1)
 

--- a/experiment_configs/templates/iaml_ranger_40981.yaml
+++ b/experiment_configs/templates/iaml_ranger_40981.yaml
@@ -9,5 +9,4 @@ FIXED_HPS:
   REPLACE: ("replace", "TRUE")
   RESPECT_UNORDERED_FACTORS: ("respect.unordered.factors", "ignore")
   SPLITRULE: ("splitrule", "gini")
-  NUM_RANDOM_SPLITS: ("num_random_splits", 1)
 

--- a/experiment_configs/templates/iaml_rpart_1067.yaml
+++ b/experiment_configs/templates/iaml_rpart_1067.yaml
@@ -1,0 +1,9 @@
+PROBLEM:
+  PROBLEM_TYPE: "yahpo"
+  ID: "iaml_rpart"
+  INSTANCE: "1067"
+  OBJECTIVE_NAMES: ["auc", "nf"]
+
+FIXED_HPS:
+  TRAINSIZE: ("trainsize", 1)
+

--- a/experiment_configs/templates/iaml_rpart_40981.yaml
+++ b/experiment_configs/templates/iaml_rpart_40981.yaml
@@ -1,0 +1,9 @@
+PROBLEM:
+  PROBLEM_TYPE: "yahpo"
+  ID: "iaml_rpart"
+  INSTANCE: "40981"
+  OBJECTIVE_NAMES: ["auc", "nf"]
+
+FIXED_HPS:
+  TRAINSIZE: ("trainsize", 1)
+

--- a/experiment_configs/templates/iaml_xgboost_1067.yaml
+++ b/experiment_configs/templates/iaml_xgboost_1067.yaml
@@ -1,0 +1,10 @@
+PROBLEM:
+  PROBLEM_TYPE: "yahpo"
+  ID: "iaml_xgboost"
+  INSTANCE: "1067"
+  OBJECTIVE_NAMES: ["auc", "nf"]
+
+FIXED_HPS:
+  BOOSTER: ("booster", "gbtree")
+  TRAINSIZE: ("trainsize", 1)
+

--- a/experiment_configs/templates/iaml_xgboost_40981.yaml
+++ b/experiment_configs/templates/iaml_xgboost_40981.yaml
@@ -1,0 +1,10 @@
+PROBLEM:
+  PROBLEM_TYPE: "yahpo"
+  ID: "iaml_xgboost"
+  INSTANCE: "40981"
+  OBJECTIVE_NAMES: ["auc", "nf"]
+
+FIXED_HPS:
+  BOOSTER: ("booster", "gbtree")
+  TRAINSIZE: ("trainsize", 1)
+

--- a/main.py
+++ b/main.py
@@ -29,14 +29,18 @@ def run_pbmohpo_bench(config, visualize: bool = False, use_mlflow: bool = False)
     path to config.yaml file. File should be in the following format.
     --
     PROBLEM:
-      DIMENSIONS: 7
       PROBLEM_TYPE: "yahpo"
+      ID: "iaml_ranger"
+      INSTANCE: "1067"
+      OBJECTIVE_NAMES: ["auc", "nf"]
 
     FIXED_HPS:
-      REPLACE: (True, "replace", "TRUE")
-      SPLITRULE: (True, "splitulre", "gini")
+      TRAINSIZE: ("trainsize", 1)
+      REPLACE: ("replace", "TRUE")
+      RESPECT_UNORDERED_FACTORS: ("respect.unordered.factors", "ignore")
+      SPLITRULE: ("splitrule", "gini")
     --
-    For options than can be set in config files, please see config.py
+    For options than can be set in config files, please see config.py.
 
     visualize: bool
     Specify whether to create plots (with default configuration) for

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "botorch",
         "gpytorch",
         "torch",
-        "yahpo-gym",
+        "yahpo-gym @ git+https://github.com/slds-lmu/yahpo_gym.git@v2#subdirectory=yahpo_gym",
         "openml",
         "lightgbm",
         "matplotlib",


### PR DESCRIPTION
- [x] debug `remove_hp_from_cs` does not work properly for xgboost scenario but removes all children that depend on booster? --> actually appears to work stable
- [x] add tests form `remove_hp_from_cs` to make sure that this does work consistently --> #22 
- [x] can we somehow make sure that people also use the needed `yahpo_data` @v2 --> not really
- [x] should cleanup all the configs we currently have --> can also do later
- [x] also use yahpo v2 for tests in workflows etc.
- [x] once v2 is merged, use released yahpo v2 in main --> will still take a while and v2 branch is protected so we are good